### PR TITLE
Change search for a config file to accept variants

### DIFF
--- a/cli
+++ b/cli
@@ -13,8 +13,11 @@ var run      = require('child_process').spawn
   , help     = argv.h || argv.help
   , notunnel = argv.n || argv.notunnel
   , exists   = require('fs').existsSync
-  , config   = exists('.popper.yml') ? yaml(file('.popper.yml')) : {}
   , script   = exists('popper.js')
+  , config   = exists('.popper')     ? yaml(file('.popper'))
+             : exists('popper.yml')  ? yaml(file('popper.yml'))
+             : exists('.popper.yml') ? yaml(file('.popper.yml'))
+             : {}
 
 if (help) return usage()
 if (browsers) config.browsers = is.str(browsers) ? browsers.split(',') : []


### PR DESCRIPTION
This will load a config from either `.popper`, `popper.yml`, or
`.popper.yml`; depending on which it can find first. If it can't
find any of them, it'll just use default options.

Should take care of #7.
